### PR TITLE
Instrucción innecesaria

### DIFF
--- a/src/main/java/helloemail/service/EmailService.java
+++ b/src/main/java/helloemail/service/EmailService.java
@@ -13,7 +13,6 @@ public class EmailService {
     public void sendEmail(String to, String subject, String body) {
         SimpleMailMessage message = new SimpleMailMessage();
 
-        message.setFrom("lunabonita547@gmail.com");
         message.setTo(to);
         message.setSubject(subject);
         message.setText(body);


### PR DESCRIPTION
No hace falta especificar desde qué dirección se envía el mensaje, ya que la propiedad spring.mail.username (que la encuentras en application.properties) ya determina la cuenta de origen.